### PR TITLE
chore(docs):  include a npx command as alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ Install from npmjs.org:
 
     npm install -g lock-treatment-tool
 
+or run using `npx`
+
+    npx -p lock-treatment-tool locktt
+
 ## Current commands
 
  * **`locktt`**


### PR DESCRIPTION
👋  Thanks for creating this tool, I've found it quite helpful when trying to avoid commiting my "local npm cache proxy" to public repositories. I generaly avoid installing tools globally so `npx` is my go-to way to run everything.

This PR just adds the command that you can use to run the tool witout installing it, using `npx`.